### PR TITLE
remove outline when selecting cell

### DIFF
--- a/src/app/components/SudokuGrid.tsx
+++ b/src/app/components/SudokuGrid.tsx
@@ -215,6 +215,7 @@ const SudokuGrid = ({ puzzle }: SudokuGridProps) => {
                           ? "cursor-pointer hover:bg-blue-100"
                           : "cursor-not-allowed"
                       }
+                      outline-none 
                       transition-all duration-200
                     `}
                     onClick={(e) => {


### PR DESCRIPTION
Selecting a cell and pressing a key caused the browser's default highlighting to show a border around the cell. 

Before:
<img width="165" alt="image" src="https://github.com/user-attachments/assets/0fe20152-4962-4189-b3ee-c7b22f89f384" />

After:

<img width="170" alt="image" src="https://github.com/user-attachments/assets/3032cd19-0322-4f87-8a3f-f23a88200a16" />
