### PR TITLE
Do not overwrite user pencil marks

### DIFF
--- a/src/app/components/SudokuGrid.tsx
+++ b/src/app/components/SudokuGrid.tsx
@@ -36,7 +36,7 @@ const SudokuGrid = ({ puzzle }: SudokuGridProps) => {
           .map(() => Array(9).fill(false))
       )
   );
-  const [manualPencilMarks, setManualPencilMarks] = useState<boolean[][]>(
+  const [manualPencilMarks, setManualPencilMarks] = useState<boolean[][][]>(
     Array(9)
       .fill(null)
       .map(() =>
@@ -324,8 +324,6 @@ const SudokuGrid = ({ puzzle }: SudokuGridProps) => {
                         (e.key === "Enter" || e.key === " ")
                       ) {
                         setSelectedCell([rowIndex, colIndex]);
-
-                        // 'ai ah' -Jonathan 2025
                       }
                     }}
                   >


### PR DESCRIPTION
Added code so that the user's manually-adjusted pencil marks are not overwritten by guesses.